### PR TITLE
[TravisCI] Hook up with Python, Ruby, CLIs, etc.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+if: branch = master OR type = pull_request
+language: python
+python: ['3.6']
+services:
+  - docker
+install:
+  - sudo apt-get install python3-pip
+  - pip install awscli
+  - pip install aws-sam-cli
+  - rvm install ruby-2.5.3
+  - ruby --version
+before_script:
+  - ./bin/setup
+script:
+  - ./bin/test


### PR DESCRIPTION
This uses Travis to set the base language as python to v3.6 and install AWS & SAM CLIs from there. Since it is easier to install Ruby via RVM (on Travis) as part of an extended `install` hook.