### PR TITLE
Native Extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 app/vendor/bundle
 .bundle/*
 .aws-sam
+
+app/Gemfile
+app/Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 if: branch = master OR type = pull_request
 language: python
 python: ['3.6']
+env:
+  - AWS_DEFAULT_REGION=us-east-1
 services:
   - docker
 install:

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,19 @@
 source 'https://rubygems.org'
 
+gem 'activesupport'
+gem 'faraday'
+gem 'net-http-persistent'
+gem 'nokogiri'
+
 group :development, :test do
+  gem 'guard'
+  gem 'guard-minitest'
   gem 'rake'
+  gem 'terminal-notifier'
 end
 
 group :test do
-  gem 'pry'
+  gem 'capybara'
   gem 'minitest'
+  gem 'pry'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,98 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (5.2.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    capybara (3.12.0)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.2)
+      xpath (~> 3.2)
     coderay (1.1.2)
+    concurrent-ruby (1.1.4)
+    connection_pool (2.2.2)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
+    ffi (1.10.0)
+    formatador (0.2.5)
+    guard (2.15.0)
+      formatador (>= 0.2.4)
+      listen (>= 2.7, < 4.0)
+      lumberjack (>= 1.0.12, < 2.0)
+      nenv (~> 0.1)
+      notiffany (~> 0.0)
+      pry (>= 0.9.12)
+      shellany (~> 0.0)
+      thor (>= 0.18.1)
+    guard-compat (1.2.1)
+    guard-minitest (2.4.6)
+      guard-compat (~> 1.2)
+      minitest (>= 3.0)
+    i18n (1.5.1)
+      concurrent-ruby (~> 1.0)
+    listen (3.1.5)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+      ruby_dep (~> 1.2)
+    lumberjack (1.0.13)
     method_source (0.9.2)
+    mini_mime (1.0.1)
+    mini_portile2 (2.4.0)
     minitest (5.11.3)
+    multipart-post (2.0.0)
+    nenv (0.3.0)
+    net-http-persistent (3.0.0)
+      connection_pool (~> 2.2)
+    nokogiri (1.10.1)
+      mini_portile2 (~> 2.4.0)
+    notiffany (0.1.1)
+      nenv (~> 0.1)
+      shellany (~> 0.0)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    public_suffix (3.0.3)
+    rack (2.0.6)
+    rack-test (1.1.0)
+      rack (>= 1.0, < 3)
     rake (12.3.2)
+    rb-fsevent (0.10.3)
+    rb-inotify (0.10.0)
+      ffi (~> 1.0)
+    regexp_parser (1.3.0)
+    ruby_dep (1.5.0)
+    shellany (0.0.1)
+    terminal-notifier (2.0.0)
+    thor (0.20.3)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport
+  capybara
+  faraday
+  guard
+  guard-minitest
   minitest
+  net-http-persistent
+  nokogiri
   pry
   rake
+  terminal-notifier
 
 BUNDLED WITH
-   2.0.1
+   1.17.3

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,7 @@
+clearing :on
+
+guard :minitest do
+  watch(%r{^test/unit/(.*)_test\.rb$})
+  watch(%r{^app/src/(.*)\.rb$})          { |m| "test/unit/#{m[1]}_test.rb" }
+  watch(%r{^test/test_helper\.rb$})      { 'test' }
+end

--- a/app/app.rb
+++ b/app/app.rb
@@ -1,7 +1,15 @@
+require 'uri'
 require 'cgi'
 require 'json'
+require 'faraday'
+require 'nokogiri'
+require 'active_support/core_ext/hash'
+require 'active_support/xml_mini'
+
+ActiveSupport::XmlMini.backend = 'Nokogiri'
 
 require_relative 'src/hello_world'
+require_relative 'src/plos_search'
 
 def handler(event:, context:)
   HelloWorld.new(event, context).perform

--- a/app/src/hello_world.rb
+++ b/app/src/hello_world.rb
@@ -46,6 +46,10 @@ class HelloWorld
           <pre>
             #{JSON.pretty_generate(ENV.to_h)}
           </pre>
+          <h2>PLOS Search</h2>
+          <code>
+            #{CGI::escapeHTML(PlosSearch.new('Ruby').search.inspect)}
+          </code>
         </body>
       </html>
     HTML

--- a/app/src/plos_search.rb
+++ b/app/src/plos_search.rb
@@ -1,0 +1,57 @@
+class PlosSearch
+  attr_reader :title
+
+  CONNECTION = Faraday.new url: 'http://api.plos.org' do |f|
+    f.adapter :net_http_persistent, pool_size: 5 do |http|
+      http.idle_timeout = 100
+      http.retry_change_requests = true
+    end
+  end
+
+  def initialize(title)
+    @title = title || 'Ruby'
+  end
+
+  def search
+    return [] if response_data_empty?
+    response_data['response']['result']['doc'].map do |doc|
+      Data.new doc['str']
+    end
+  end
+
+  private
+
+  def response
+    @response ||= CONNECTION.get '/search', search_params
+  end
+
+  def search_params
+    {
+      q: "title:#{URI.escape(title)}",
+      fl: 'id,title,abstract',
+      wt: 'xml'
+    }
+  end
+
+  def response_xml
+    response.status == 200 ? response.body : ''
+  end
+
+  def response_data
+    @response_data ||= Hash.from_xml(response_xml)
+  end
+
+  def response_data_empty?
+    return true if response_data.empty?
+    return true if response_data['response'].nil?
+    response_data['response']['result']['numFound'].to_i == 0
+  end
+
+  class Data
+    attr_reader :id, :title, :abstract
+    def initialize(attrs)
+      @id, @title, @abstract = attrs
+    end
+  end
+
+end

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -12,7 +12,10 @@ brew upgrade ruby-build || true
 rbenv install --skip-existing 2.5.3
 rbenv local 2.5.3
 
-gem install bundler
+gem uninstall -aIx bundler
+gem install bundler -v 1.17.3
+
+rm -rf app/vendor/bundle
 bundle install --path app/vendor/bundle
 
 aws s3 mb "s3://$CF_BUCKET_NAME"

--- a/bin/build
+++ b/bin/build
@@ -2,14 +2,22 @@
 
 set -e
 
-sam build
-# sam build --use-container
+# Clean any previous comingled bundle dir.
+rm -rf ./app/vendor/bundle
 
-# Remove top level vendor directory added by `sam build` above.
-rm -rf ./vendor
+# Copy these to app so build can use them. Symlink will not work.
+rm -rf ./app/Gemfile
+rm -rf ./app/Gemfile.lock
+cp ./Gemfile ./app/Gemfile
+cp ./Gemfile.lock ./app/Gemfile.lock
 
-# Remove ./.bundle/config to avoid frozen and bundle without setting.
-rm -rf ./.bundle/config
+# Ensure native extensions are compatible.
+sam build --use-container
 
-# Now re-setup local development.
-./bin/update
+# Copy the build bundle to allow server native extensions to work.
+rm -rf ./app/vendor/bundle
+cp -R ./.aws-sam/build/HelloWorldFunction/vendor/bundle ./app/vendor/bundle
+
+# Make a comingled bundle dir for build and this platform.
+rm -rf ./.bundle
+bundle install --path app/vendor/bundle

--- a/bin/server
+++ b/bin/server
@@ -2,5 +2,7 @@
 
 set -e
 
-rm -rf ./.aws-sam
+# Delete the static build to avoid local server using it.
+rm -rf ./.aws-sam/build
+
 sam local start-api

--- a/bin/setup
+++ b/bin/setup
@@ -2,4 +2,7 @@
 
 set -e
 
+rm -rf ./.bundle
 bundle install --path app/vendor/bundle --no-deployment
+
+./bin/build

--- a/bin/watch
+++ b/bin/watch
@@ -2,4 +2,4 @@
 
 set -e
 
-./bin/setup
+bundle exec guard

--- a/template.yaml
+++ b/template.yaml
@@ -14,6 +14,8 @@ Resources:
       CodeUri: app/
       Handler: app.handler
       Runtime: ruby2.5
+      MemorySize: 256
+      Timeout: 10
       Environment:
         Variables:
           PARAM1: VALUE

--- a/test/unit/plos_search_test.rb
+++ b/test/unit/plos_search_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class PlosSearchTest < HelloSpec
+  it '#search - Ruby' do
+    data = search('Ruby')
+    data.length.must_equal 2
+    d = data[0]
+    d.id.must_equal '10.1371/journal.pone.0077003'
+    d.title.must_equal 'Glucose Transporter Expression in an Avian Nectarivore: The Ruby-Throated Hummingbird (Archilochus colubris)'
+  end
+
+  private
+
+  def search(title)
+    PlosSearch.new(title).search
+  end
+end


### PR DESCRIPTION
The goal of these changes is to introduce basic gems with native C extensions into the development, test, and deploy process. The high level summary of changes to meet this objective include:

* Added Nokogiri gem which builds against libxml.
* Get some XML from a service ([PLOS](https://www.plos.org)) via HTTP.
* Leverage Nokogiri via ActiveSupport to parse PLOS results.
* Made sure to use Bundler 1.17.3 in project. Details below.
* Used `sam build --use-container` in build script.
* Ensure Docker development local tests share platform native gems.
* Copy Gemfile files to `app` directory when building. Git ignore these.

Other smaller changes include:

* Add some debug HTML to the page to show PLO requests.
* Added Guard for rapid test feedback.
* Increase memory size to 256 megabytes.
* Increase lambda timeout to 10 seconds.

About Bundler 2 and how we juggled the `.aws-build` directory to get both local tests and the development server to work together. First, errors when building can often return a very un-helpful message.

```
{"jsonrpc": "2.0", "id": 1, "error": {"code": 400, "message": "PythonPipBuilder:ResolveDependencies - Could not satisfy the requirement: requests==2.20.0"}}
```

To over come this, we can use the following command to debug the errors in the build process. This is how I found that using Bundler v2 locally will cause errors for the build Docker container.

```shell
docker run -v $(pwd):/var/task \
  lambci/lambda:build-ruby2.5 \
  bash -c "bundle install --without development test --verbose"
```