### PR TITLE
DynamoDB

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'activesupport'
+gem 'aws-record'
 gem 'faraday'
 gem 'net-http-persistent'
 gem 'nokogiri'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,19 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    aws-eventstream (1.0.1)
+    aws-partitions (1.131.0)
+    aws-record (2.2.0)
+      aws-sdk-dynamodb (~> 1.18)
+    aws-sdk-core (3.45.0)
+      aws-eventstream (~> 1.0)
+      aws-partitions (~> 1.0)
+      aws-sigv4 (~> 1.0)
+      jmespath (~> 1.0)
+    aws-sdk-dynamodb (1.19.0)
+      aws-sdk-core (~> 3, >= 3.39.0)
+      aws-sigv4 (~> 1.0)
+    aws-sigv4 (1.0.3)
     capybara (3.12.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -38,6 +51,7 @@ GEM
       minitest (>= 3.0)
     i18n (1.5.1)
       concurrent-ruby (~> 1.0)
+    jmespath (1.4.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -83,6 +97,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport
+  aws-record
   capybara
   faraday
   guard

--- a/README.md
+++ b/README.md
@@ -167,3 +167,10 @@ docker run -v $(pwd):/var/task \
   bash -c "bundle install --without development test --verbose"
 ```
 
+#### DynamoDB
+
+Allow Lambda to own a DynamoDB instance and use it for storing results of API queries to PLOS. Details to support this change include:
+
+* Change API Gateway to use `/{resource+}` to slurp all path params.
+* Pass the `query` query parameter down to the `PlosSearch` object.
+

--- a/README.md
+++ b/README.md
@@ -171,6 +171,28 @@ docker run -v $(pwd):/var/task \
 
 Allow Lambda to own a DynamoDB instance and use it for storing results of API queries to PLOS. Details to support this change include:
 
+
+* Added [Aws::Record](https://github.com/aws/aws-sdk-ruby-record) gem to the project.
 * Change API Gateway to use `/{resource+}` to slurp all path params.
 * Pass the `query` query parameter down to the `PlosSearch` object.
+* New `PlosSearchTable` DynamoDB PORO with simple schema & migration class methods.
+* Made `PlosSearch#search` find or create DynamoDB records.
+* Lazily create DynamoDB tables in development & test envs.
+* Added an `Policies` section to the template.yml with full access to the new `PlosSearchTable` arn.
+
+Some helpful DynamoDB resources when getting started with SAM & Ruby.
+
+* [AWS::Serverless::SimpleTable in AWS SAM](https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlesssimpletable)
+* [AWS::DynamoDB::Table in CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html)
+* [Amazon DynamoDB–related content from AWS re:Invent 2018](https://aws.amazon.com/blogs/database/amazon-dynamodb-related-content-from-aws-reinvent-2018/)
+* [The Aws::Record Gem](https://github.com/aws/aws-sdk-ruby-record)
+* [Announcing Amazon DynamoDB On-Demand](https://aws.amazon.com/about-aws/whats-new/2018/11/announcing-amazon-dynamodb-on-demand/)
+* [Future SAM Billing Mode Issue](https://github.com/awslabs/serverless-application-model/pull/705)
+
+Other smaller changes include:
+
+* Added a STAGE parameter to CloudFormation template and "prod" to deploy script.
+* Created a simple Myenv PORO to check current ENV stuff.
+* Renamed some logical resource id names in template.yml.
+
 

--- a/app/app.rb
+++ b/app/app.rb
@@ -5,11 +5,16 @@ require 'faraday'
 require 'nokogiri'
 require 'active_support/core_ext/hash'
 require 'active_support/xml_mini'
+require 'aws-record'
 
 ActiveSupport::XmlMini.backend = 'Nokogiri'
 
+require_relative 'src/myenv'
 require_relative 'src/hello_world'
 require_relative 'src/plos_search'
+require_relative 'src/plos_search_table'
+
+PlosSearchTable.create!
 
 def handler(event:, context:)
   HelloWorld.new(event, context).perform

--- a/app/src/hello_world.rb
+++ b/app/src/hello_world.rb
@@ -28,6 +28,13 @@ class HelloWorld
 
   private
 
+  def plos_search
+    @plos_search ||= begin
+      title = event['queryStringParameters']['query'] || 'Ruby'
+      PlosSearch.new(title)
+    end
+  end
+
   def debug_html
     <<-HTML
       <!DOCTYPE html>
@@ -48,7 +55,7 @@ class HelloWorld
           </pre>
           <h2>PLOS Search</h2>
           <code>
-            #{CGI::escapeHTML(PlosSearch.new('Ruby').search.inspect)}
+            #{CGI::escapeHTML(plos_search.search.inspect)}
           </code>
         </body>
       </html>

--- a/app/src/hello_world.rb
+++ b/app/src/hello_world.rb
@@ -30,7 +30,8 @@ class HelloWorld
 
   def plos_search
     @plos_search ||= begin
-      title = event['queryStringParameters']['query'] || 'Ruby'
+      qsp = event['queryStringParameters']
+      title = qsp && qsp['query'] ? qsp['query'] : 'Ruby'
       PlosSearch.new(title)
     end
   end

--- a/app/src/myenv.rb
+++ b/app/src/myenv.rb
@@ -1,0 +1,23 @@
+module Myenv
+  def stage
+    ENV['STAGE']
+  end
+
+  def dev?
+    stage == 'dev'
+  end
+
+  def test?
+    stage == 'test'
+  end
+
+  def prod?
+    stage == 'prod'
+  end
+
+  def staging?
+    stage == 'staging'
+  end
+
+  extend self
+end

--- a/app/src/plos_search.rb
+++ b/app/src/plos_search.rb
@@ -51,7 +51,15 @@ class PlosSearch
     attr_reader :id, :title, :abstract
     def initialize(attrs)
       @id, @title, @abstract = attrs
+      find_or_create_dyno_dna_record
+    end
+
+    private
+
+    def find_or_create_dyno_dna_record
+      return if PlosSearchTable.find id: id
+      plos = PlosSearchTable.new id: id, title: title, abstract: abstract
+      plos.save
     end
   end
-
 end

--- a/app/src/plos_search_table.rb
+++ b/app/src/plos_search_table.rb
@@ -1,0 +1,28 @@
+class PlosSearchTable
+  include Aws::Record
+  set_table_name "plos-search-#{Myenv.stage}"
+  string_attr :id, hash_key: true
+  string_attr :title
+  string_attr :abstract
+
+  class << self
+    def create!
+      return unless Myenv.dev? || Myenv.test?
+      table_config.migrate!
+    end
+
+    def delete!
+      return unless Myenv.dev? || Myenv.test?
+      Aws::Record::TableMigration.new(self).delete!
+    end
+
+    private
+
+    def table_config
+      @table_config ||= Aws::Record::TableConfig.define do |t|
+        t.model_class PlosSearchTable
+        t.billing_mode 'PAY_PER_REQUEST'
+      end
+    end
+  end
+end

--- a/bin/build
+++ b/bin/build
@@ -16,7 +16,7 @@ sam build --use-container
 
 # Copy the build bundle to allow server native extensions to work.
 rm -rf ./app/vendor/bundle
-cp -R ./.aws-sam/build/HelloWorldFunction/vendor/bundle ./app/vendor/bundle
+cp -R ./.aws-sam/build/MyFunction/vendor/bundle ./app/vendor/bundle
 
 # Make a comingled bundle dir for build and this platform.
 rm -rf ./.bundle

--- a/bin/deploy
+++ b/bin/deploy
@@ -14,7 +14,7 @@ sam package \
 sam deploy \
     --template-file ./.aws-sam/build/packaged.yaml \
     --stack-name hello-757rb-lambda \
-    --capabilities CAPABILITY_IAM
-    # --parameter-overrides MyParameterSample=MySampleValue
+    --capabilities CAPABILITY_IAM \
+    --parameter-overrides StageName=prod
 
 ./bin/info

--- a/template.yaml
+++ b/template.yaml
@@ -2,13 +2,20 @@ AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: Using Ruby with AWS Lambda & SAM by 757rb.org
 
-Globals:
-  Function:
-    Timeout: 3
+Parameters:
+
+  StageName:
+    Type: String
+    Default: dev
+    AllowedValues:
+      - dev
+      - test
+      - staging
+      - prod
 
 Resources:
 
-  HelloWorldFunction:
+  MyFunction:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri: app/
@@ -18,24 +25,44 @@ Resources:
       Timeout: 10
       Environment:
         Variables:
-          PARAM1: VALUE
+          STAGE: !Ref StageName
+      Policies:
+        - Version: "2012-10-17"
+          Statement:
+            - Effect: Allow
+              Action:
+                - dynamodb:*
+              Resource:
+                - !GetAtt PlosSearchTable.Arn
       Events:
-        HelloWorld:
+        MyApi:
           Type: Api
           Properties:
             Path: /{resource+}
             Method: get
 
+  PlosSearchTable:
+    Type: AWS::Serverless::SimpleTable
+    Properties:
+      TableName: !Join
+        - ''
+        - - plos-search
+          - '-'
+          - !Ref StageName
+      PrimaryKey:
+        Name: id
+        Type: String
+
 Outputs:
 
-  HelloWorldApi:
-    Description: "API Gateway endpoint URL for Prod stage for Hello World function"
+  MyApi:
+    Description: API Gateway endpoint URL for Prod stage for Hello World function
     Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
 
-  HelloWorldFunction:
-    Description: "Hello World Lambda Function ARN"
-    Value: !GetAtt HelloWorldFunction.Arn
+  Function:
+    Description: Lambda function ARN.
+    Value: !GetAtt MyFunction.Arn
 
-  HelloWorldFunctionIamRole:
-    Description: "Implicit IAM Role created for Hello World function"
-    Value: !GetAtt HelloWorldFunctionRole.Arn
+  FunctionIamRole:
+    Description: Implicit IAM Role created for the function.
+    Value: !GetAtt MyFunctionRole.Arn

--- a/template.yaml
+++ b/template.yaml
@@ -23,7 +23,7 @@ Resources:
         HelloWorld:
           Type: Api
           Properties:
-            Path: /hello
+            Path: /{resource+}
             Method: get
 
 Outputs:

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,4 @@
+ENV['STAGE'] = 'test'
 require 'bundler/setup'
 Bundler.require :development, :test
 require_relative '../app/app'

--- a/test/unit/plos_search_table_test.rb
+++ b/test/unit/plos_search_table_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class PlosSearchTableTest < HelloSpec
+
+  before do
+    plos = test_find
+    plos.delete! if plos
+  end
+
+  it 'can save and find object' do
+    refute test_find
+    plos = PlosSearchTable.new id: 'test',
+                               title: 'Test Title',
+                               abstract: 'Test Abstract'
+    assert plos.save
+    assert test_find
+  end
+
+  private
+
+  def test_find
+    PlosSearchTable.find(id: 'test')
+  end
+end


### PR DESCRIPTION
Allow Lambda to own a DynamoDB instance and use it for storing results of API queries to PLOS. Details to support this change include:


* Added [Aws::Record](https://github.com/aws/aws-sdk-ruby-record) gem to the project.
* Change API Gateway to use `/{resource+}` to slurp all path params.
* Pass the `query` query parameter down to the `PlosSearch` object.
* New `PlosSearchTable` DynamoDB PORO with simple schema & migration class methods.
* Made `PlosSearch#search` find or create DynamoDB records.
* Lazily create DynamoDB tables in development & test envs.
* Added an `Policies` section to the template.yml with full access to the new `PlosSearchTable` arn.

Some helpful DynamoDB resources when getting started with SAM & Ruby.

* [AWS::Serverless::SimpleTable in AWS SAM](https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlesssimpletable)
* [AWS::DynamoDB::Table in CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html)
* [Amazon DynamoDB–related content from AWS re:Invent 2018](https://aws.amazon.com/blogs/database/amazon-dynamodb-related-content-from-aws-reinvent-2018/)
* [The Aws::Record Gem](https://github.com/aws/aws-sdk-ruby-record)
* [Announcing Amazon DynamoDB On-Demand](https://aws.amazon.com/about-aws/whats-new/2018/11/announcing-amazon-dynamodb-on-demand/)
* [Future SAM Billing Mode Issue](https://github.com/awslabs/serverless-application-model/pull/705)

Other smaller changes include:

* Added a STAGE parameter to CloudFormation template and "prod" to deploy script.
* Created a simple Myenv PORO to check current ENV stuff.
* Renamed some logical resource id names in template.yml.

